### PR TITLE
feat: add dual CLI mode support

### DIFF
--- a/src/ota_image_builder/__main__.py
+++ b/src/ota_image_builder/__main__.py
@@ -18,6 +18,7 @@ from multiprocessing import freeze_support
 
 OTA_IMAGE_TOOLS = "ota_image_tools"
 
+# NOTE: freeze_support should be executed as early as possible.
 if __name__ == "__main__":
     freeze_support()
 
@@ -29,11 +30,11 @@ if __name__ == "__main__":
     # special treatment when the program is called with name ota_image_tools.
     _cli_name = os.path.basename(sys.argv[0])
     if _cli_name.replace("-", "_").startswith(OTA_IMAGE_TOOLS):
-        from ota_image_tools.__main__ import main
+        from ota_image_tools.__main__ import main as _image_tool_main
 
-        main()
+        _image_tool_main()
 
     else:
-        from ota_image_builder.main import main
+        from ota_image_builder.main import main as _builder_main
 
-        main()
+        _builder_main()

--- a/src/ota_image_builder/__main__.py
+++ b/src/ota_image_builder/__main__.py
@@ -22,9 +22,13 @@ if __name__ == "__main__":
     freeze_support()
 
 if __name__ == "__main__":
+    from ota_image_builder._common import configure_logging
+
+    configure_logging()
+
     # special treatment when the program is called with name ota_image_tools.
     _cli_name = os.path.basename(sys.argv[0])
-    if _cli_name.replace("-", "_") == OTA_IMAGE_TOOLS:
+    if _cli_name.replace("-", "_").startswith(OTA_IMAGE_TOOLS):
         import ota_image_tools.__main__ as _ota_image_tool_cli
 
         # NOTE: the __main__ module will be executed at import time

--- a/src/ota_image_builder/__main__.py
+++ b/src/ota_image_builder/__main__.py
@@ -29,10 +29,9 @@ if __name__ == "__main__":
     # special treatment when the program is called with name ota_image_tools.
     _cli_name = os.path.basename(sys.argv[0])
     if _cli_name.replace("-", "_").startswith(OTA_IMAGE_TOOLS):
-        import ota_image_tools.__main__ as _ota_image_tool_cli
+        from ota_image_tools.__main__ import main
 
-        # NOTE: the __main__ module will be executed at import time
-        _ = _ota_image_tool_cli
+        main()
 
     else:
         from ota_image_builder.main import main

--- a/src/ota_image_builder/__main__.py
+++ b/src/ota_image_builder/__main__.py
@@ -12,11 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+import sys
 from multiprocessing import freeze_support
+
+OTA_IMAGE_TOOLS = "ota_image_tools"
 
 if __name__ == "__main__":
     freeze_support()
 
-    from ota_image_builder.main import main
+if __name__ == "__main__":
+    # special treatment when the program is called with name ota_image_tools.
+    _cli_name = os.path.basename(sys.argv[0])
+    if _cli_name.replace("-", "_") == OTA_IMAGE_TOOLS:
+        import ota_image_tools.__main__ as _ota_image_tool_cli
 
-    main()
+        # NOTE: the __main__ module will be executed at import time
+        _ = _ota_image_tool_cli
+
+    else:
+        from ota_image_builder.main import main
+
+        main()


### PR DESCRIPTION
This PR add supports for dual CLI mode. 
In normal case, the CLI will expose the `ota-image-builder` interface. But when the single binary CLI is called with name `ota-image-tools.*`, it will reveal the CLI interface of `ota-image-tools`.

A common way to use dual CLI mode is by creating `ota-image-tools` symlink points to the ota-image-builder bin.