### PR TITLE
feat: add pack-artifact command, supports reproducible artifact packing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires = [
 name = "ota-image-builder"
 description = "OTA Image Builder."
 dynamic = ["optional-dependencies"]
-version = "0.2.1"
+version = "0.3.0"
 # unfortunately, up to 20250909, dependabot has a bug
 #   that prevents it from working when readme is specified.
 # readme = "README.md"

--- a/src/ota_image_builder/_version.py
+++ b/src/ota_image_builder/_version.py
@@ -27,5 +27,5 @@ __version__: str
 __version_tuple__: VERSION_TUPLE
 version_tuple: VERSION_TUPLE
 
-__version__ = version = "0.2.1"
-__version_tuple__ = version_tuple = (0, 2, 1)
+__version__ = version = "0.3.0"
+__version_tuple__ = version_tuple = (0, 3, 0)

--- a/src/ota_image_builder/cmds/__init__.py
+++ b/src/ota_image_builder/cmds/__init__.py
@@ -17,6 +17,7 @@ from .add_otaclient_package import add_otaclient_package_cmd_args
 from .add_otaclient_package_compat import add_otaclient_package_compat_cmd_args
 from .finalize import finalize_cmd_args
 from .init import init_cmd_args
+from .pack_artifact import pack_artifact_cmd_args
 from .prepare_sysimg import prepare_sysimg_cmd_args
 from .sign import sign_cmd_args
 
@@ -28,4 +29,5 @@ __all__ = [
     "add_otaclient_package_cmd_args",
     "add_otaclient_package_compat_cmd_args",
     "prepare_sysimg_cmd_args",
+    "pack_artifact_cmd_args",
 ]

--- a/src/ota_image_builder/cmds/pack_artifact.py
+++ b/src/ota_image_builder/cmds/pack_artifact.py
@@ -50,6 +50,7 @@ def _pack_artifact(_image_root: Path, _output: Path):
             for _file in files:
                 _src = curdir / _file
                 _relative_src = relative_curdir / _file
+
                 _src_zipinfo = ZipInfo.from_file(
                     filename=_src, arcname=str(_relative_src)
                 )

--- a/src/ota_image_builder/cmds/pack_artifact.py
+++ b/src/ota_image_builder/cmds/pack_artifact.py
@@ -16,9 +16,12 @@ from __future__ import annotations
 
 import logging
 import os
+import shutil
 from pathlib import Path
 from typing import TYPE_CHECKING
 from zipfile import ZIP_STORED, ZipFile, ZipInfo
+
+from ota_image_libs.v1.consts import IMAGE_INDEX_FNAME
 
 from ota_image_builder._common import check_if_valid_ota_image, exit_with_err_msg
 
@@ -30,40 +33,76 @@ logger = logging.getLogger(__name__)
 
 REPORT_BATCH_SIZE = 10_000
 DEFAULT_TIMESTAMP = (2009, 1, 1, 0, 0, 0)
+RW_CHUNK_SIZE = 8 * 1024 * 1024  # 8MiB
+
+
+def _add_dir(zipf: ZipFile, filename: Path, arcname: Path | str) -> None:
+    """
+    Add a directory to the OTA image zipfile. The src must be a directory.
+    """
+    _zipinfo = ZipInfo.from_file(
+        filename=f"{str(filename).rstrip('/')}/",
+        arcname=f"{str(arcname).rstrip('/')}/",
+    )
+    _zipinfo.CRC = 0
+    _zipinfo.date_time = DEFAULT_TIMESTAMP
+    zipf.mkdir(_zipinfo, mode=0o755)
+
+
+def _add_file(zipf: ZipFile, filename: Path, arcname: Path | str) -> None:
+    """
+    Add a regular file to the OTA image zipfile. The src must be a regular file.
+
+    Basically a copy of the ZipFile.writestr method.
+    """
+    _zipinfo = ZipInfo.from_file(filename=filename, arcname=str(arcname))
+    _zipinfo.date_time = DEFAULT_TIMESTAMP
+    _zipinfo.compress_type = zipf.compression
+    _zipinfo.compress_level = zipf.compresslevel
+    _zipinfo.external_attr |= 0o644 << 16  # rw_r_r_
+
+    with open(filename, "rb") as src, zipf.open(_zipinfo, "w") as dst:
+        shutil.copyfileobj(src, dst, RW_CHUNK_SIZE)
 
 
 def _pack_artifact(_image_root: Path, _output: Path):
-    _file_count = 0
+    _file_count, _top_level = 0, True
     with ZipFile(_output, mode="w", compression=ZIP_STORED) as output_f:
         for curdir, _, files in os.walk(_image_root):
             curdir = Path(curdir)
             relative_curdir = curdir.relative_to(_image_root)
 
-            _curdir_zipinfo = ZipInfo.from_file(
-                filename=f"{str(curdir).rstrip('/')}/",
-                arcname=f"{str(relative_curdir).rstrip('/')}/",
-            )
-            _curdir_zipinfo.CRC = 0
-            _curdir_zipinfo.date_time = DEFAULT_TIMESTAMP
-            output_f.mkdir(_curdir_zipinfo, mode=0o755)
+            if _top_level:
+                _top_level = False
 
-            for _file in sorted(files):
-                _src = curdir / _file
-                _relative_src = relative_curdir / _file
-
-                _src_zipinfo = ZipInfo.from_file(
-                    filename=_src, arcname=str(_relative_src)
+                # add the index.json file as the first file entry in zipfile,
+                #   effectively defining the manifest for this image.
+                # see https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT chapter 4.1.11
+                #   for more details about ZIP manifest.
+                _add_file(
+                    zipf=output_f,
+                    filename=curdir / IMAGE_INDEX_FNAME,
+                    arcname=IMAGE_INDEX_FNAME,
                 )
-                _src_zipinfo.date_time = DEFAULT_TIMESTAMP
-                _src_zipinfo.compress_type = output_f.compression
-                _src_zipinfo.compress_level = output_f.compresslevel
-                # NOTE: for OTA image, we have regulated the file size(less than 32MiB pre-blob),
-                #       so just directly read the whole chunk is not a problem.
-                output_f.writestr(_src_zipinfo, _src.read_bytes())
                 _file_count += 1
 
-                if _file_count % REPORT_BATCH_SIZE == 0:
-                    print(f"Packing in-progress: {_file_count} files are packed ...")
+                for _fname in sorted(files):
+                    if _fname == IMAGE_INDEX_FNAME:
+                        continue
+                    _add_file(zipf=output_f, filename=curdir / _fname, arcname=_fname)
+                    _file_count += 1
+
+            else:
+                _add_dir(zipf=output_f, filename=curdir, arcname=relative_curdir)
+                for _file in sorted(files):
+                    _src = curdir / _file
+                    _relative_src = relative_curdir / _file
+                    _add_file(zipf=output_f, filename=_src, arcname=_relative_src)
+                    _file_count += 1
+                    if _file_count % REPORT_BATCH_SIZE == 0:
+                        print(
+                            f"Packing in-progress: {_file_count} files are packed ..."
+                        )
 
 
 def pack_artifact_cmd_args(

--- a/src/ota_image_builder/cmds/pack_artifact.py
+++ b/src/ota_image_builder/cmds/pack_artifact.py
@@ -1,0 +1,86 @@
+# Copyright 2025 TIER IV, INC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING
+from zipfile import ZIP_STORED, ZipFile
+
+from ota_image_builder._common import check_if_valid_ota_image, exit_with_err_msg
+
+if TYPE_CHECKING:
+    from argparse import ArgumentParser, Namespace, _SubParsersAction
+
+
+logger = logging.getLogger(__name__)
+
+
+def _pack_artifact(_image_root: Path, _output: Path):
+    with ZipFile(_output, mode="w", compression=ZIP_STORED) as output_f:
+        for curdir, _, files in os.walk(_image_root):
+            curdir = Path(curdir)
+            relative_curdir = curdir.relative_to(_image_root)
+
+            output_f.mkdir(str(relative_curdir), mode=0o755)
+            for _file in files:
+                output_f.write(curdir / _file)
+
+
+def pack_artifact_cmd_args(
+    sub_arg_parser: _SubParsersAction[ArgumentParser], *parent_parser: ArgumentParser
+) -> None:
+    pack_artifact_arg_parser = sub_arg_parser.add_parser(
+        name="pack-artifact",
+        help=(_help_txt := "Pack OTA image into one ZIP archive."),
+        description=_help_txt,
+        parents=parent_parser,
+    )
+    pack_artifact_arg_parser.add_argument(
+        "-o",
+        help="The location to output the ZIP archive to.",
+        required=True,
+    )
+    pack_artifact_arg_parser.add_argument(
+        "image_root",
+        help="The location of the OTA image.",
+    )
+    pack_artifact_arg_parser.set_defaults(handler=pack_artifact_cmd)
+
+
+def pack_artifact_cmd(args: Namespace) -> None:
+    logger.debug(f"calling {pack_artifact_cmd.__name__} with {args}")
+    image_root = Path(args.image_root)
+    output = Path(args.o)
+    if output.exists():
+        exit_with_err_msg(f"{output} already exists!")
+    print(f"Will output the ZIP archive to {output}.")
+
+    if not image_root.is_dir():
+        exit_with_err_msg(f"{image_root} is not a directory!")
+
+    if not check_if_valid_ota_image(image_root):
+        exit_with_err_msg(f"{image_root} doesn't hold a valid OTA image.")
+
+    try:
+        _pack_artifact(image_root, output)
+        print(f"Packed artifact is populated to {output}.")
+    except Exception as e:
+        _err_msg = (
+            f"failed to pack OTA image at {image_root} and output to {output}: {e}"
+        )
+        logger.error(_err_msg, exc_info=e)
+        exit_with_err_msg(_err_msg)

--- a/src/ota_image_builder/cmds/pack_artifact.py
+++ b/src/ota_image_builder/cmds/pack_artifact.py
@@ -47,7 +47,7 @@ def _pack_artifact(_image_root: Path, _output: Path):
             _curdir_zipinfo.date_time = DEFAULT_TIMESTAMP
             output_f.mkdir(_curdir_zipinfo, mode=0o755)
 
-            for _file in files:
+            for _file in sorted(files):
                 _src = curdir / _file
                 _relative_src = relative_curdir / _file
 

--- a/src/ota_image_builder/cmds/pack_artifact.py
+++ b/src/ota_image_builder/cmds/pack_artifact.py
@@ -40,7 +40,7 @@ def _pack_artifact(_image_root: Path, _output: Path):
 
             output_f.mkdir(str(relative_curdir), mode=0o755)
             for _file in files:
-                output_f.write(curdir / _file)
+                output_f.write(filename=curdir / _file, arcname=relative_curdir / _file)
                 _file_count += 1
 
                 if _file_count % REPORT_BATCH_SIZE == 0:
@@ -58,6 +58,7 @@ def pack_artifact_cmd_args(
     )
     pack_artifact_arg_parser.add_argument(
         "-o",
+        "--output",
         help="The location to output the ZIP archive to.",
         required=True,
     )
@@ -71,7 +72,7 @@ def pack_artifact_cmd_args(
 def pack_artifact_cmd(args: Namespace) -> None:
     logger.debug(f"calling {pack_artifact_cmd.__name__} with {args}")
     image_root = Path(args.image_root)
-    output = Path(args.o)
+    output = Path(args.output)
     if output.exists():
         exit_with_err_msg(f"{output} already exists!")
     print(f"Will output the ZIP archive to {output}.")

--- a/src/ota_image_builder/cmds/pack_artifact.py
+++ b/src/ota_image_builder/cmds/pack_artifact.py
@@ -71,7 +71,11 @@ def pack_artifact_cmd_args(
 ) -> None:
     pack_artifact_arg_parser = sub_arg_parser.add_parser(
         name="pack-artifact",
-        help=(_help_txt := "Pack OTA image into one ZIP archive."),
+        help=(
+            _help_txt
+            := "Pack OTA image into one ZIP archive. This cmd implements reproducible build, "
+            "for the same OTA image input, the output artifact is always the same."
+        ),
         description=_help_txt,
         parents=parent_parser,
     )

--- a/src/ota_image_builder/cmds/pack_artifact.py
+++ b/src/ota_image_builder/cmds/pack_artifact.py
@@ -47,7 +47,10 @@ def _pack_artifact(_image_root: Path, _output: Path):
                     filename=_src, arcname=str(_relative_src)
                 )
                 _src_zipinfo.date_time = DEFAULT_TIMESTAMP
-
+                _src_zipinfo.compress_type = output_f.compression
+                _src_zipinfo.compress_level = output_f.compresslevel
+                # NOTE: for OTA image, we have regulated the file size(less than 32MiB pre-blob),
+                #       so just directly read the whole chunk is not a problem.
                 output_f.writestr(_src_zipinfo, _src.read_bytes())
                 _file_count += 1
 

--- a/src/ota_image_builder/cmds/pack_artifact.py
+++ b/src/ota_image_builder/cmds/pack_artifact.py
@@ -39,7 +39,14 @@ def _pack_artifact(_image_root: Path, _output: Path):
             curdir = Path(curdir)
             relative_curdir = curdir.relative_to(_image_root)
 
-            output_f.mkdir(str(relative_curdir), mode=0o755)
+            _curdir_zipinfo = ZipInfo.from_file(
+                filename=f"{str(curdir).rstrip('/')}/",
+                arcname=f"{str(relative_curdir).rstrip('/')}/",
+            )
+            _curdir_zipinfo.CRC = 0
+            _curdir_zipinfo.date_time = DEFAULT_TIMESTAMP
+            output_f.mkdir(_curdir_zipinfo, mode=0o755)
+
             for _file in files:
                 _src = curdir / _file
                 _relative_src = relative_curdir / _file

--- a/src/ota_image_builder/cmds/pack_artifact.py
+++ b/src/ota_image_builder/cmds/pack_artifact.py
@@ -28,8 +28,11 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+REPORT_BATCH_SIZE = 10_000
+
 
 def _pack_artifact(_image_root: Path, _output: Path):
+    _file_count = 0
     with ZipFile(_output, mode="w", compression=ZIP_STORED) as output_f:
         for curdir, _, files in os.walk(_image_root):
             curdir = Path(curdir)
@@ -38,6 +41,10 @@ def _pack_artifact(_image_root: Path, _output: Path):
             output_f.mkdir(str(relative_curdir), mode=0o755)
             for _file in files:
                 output_f.write(curdir / _file)
+                _file_count += 1
+
+                if _file_count % REPORT_BATCH_SIZE == 0:
+                    print(f"Packing in-progress: {_file_count} files are packed ...")
 
 
 def pack_artifact_cmd_args(

--- a/src/ota_image_builder/main.py
+++ b/src/ota_image_builder/main.py
@@ -29,6 +29,7 @@ from ota_image_builder.cmds import (
     add_otaclient_package_compat_cmd_args,
     finalize_cmd_args,
     init_cmd_args,
+    pack_artifact_cmd_args,
     prepare_sysimg_cmd_args,
     sign_cmd_args,
 )
@@ -92,6 +93,7 @@ def main():
     add_otaclient_package_compat_cmd_args(sub_arg_parser)
     finalize_cmd_args(sub_arg_parser)
     sign_cmd_args(sub_arg_parser)
+    pack_artifact_cmd_args(sub_arg_parser)
 
     # ------ top-level args parsing ----- #
     args = arg_parser.parse_args()

--- a/uv.lock
+++ b/uv.lock
@@ -235,7 +235,7 @@ wheels = [
 
 [[package]]
 name = "ota-image-builder"
-version = "0.2.1"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Introduction

This PR introduces a new command `pack-artifact` to pack an OTA image into a ZIP file, in a reproducible way, all the build from the same OTA image will output exactly the same OTA image artifact. 
Especially, the `index.json` file will be added as the first file entry of the file, effectively making the `index.json` file the manifest of the OTA image zip file (for what is ZIP manifest, see chapter 4.1.11 in [ZIP specification](https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT)).

This PR will bump the ota-image-builder version to 0.3.0.