### PR TITLE
feat(prepare-sysimg): fix up /etc/resolv.conf when needed

### DIFF
--- a/src/ota_image_builder/cmds/prepare_sysimg.py
+++ b/src/ota_image_builder/cmds/prepare_sysimg.py
@@ -62,6 +62,23 @@ BACKWARD_COMPAT_PA = [
 
 GLOB_SPECIAL_CHARS = re.compile(r"[\*\?\[\]\|]")
 
+# On a systemd-resolved managed system, /etc/resolv.conf is expected to be a
+# relative symlink pointing to the stub resolv.conf maintained at runtime by
+# systemd-resolved. The stub file itself lives under /run and thus does NOT
+# exist in a (cleaned) rootfs image, the symlink is intentionally "dangling".
+RESOLV_CONF_RELPATH = "etc/resolv.conf"
+RESOLV_CONF_SYMLINK_TARGET = "../run/systemd/resolve/stub-resolv.conf"
+
+# Matches a `nameserver <addr>` directive line (leading whitespace tolerated),
+# with <addr> restricted to IPv4/IPv6-like values (hex digits, `:` and `.`).
+# Commented out lines (starting with `#`) don't match and are thus ignored.
+NAMESERVER_PA = re.compile(r"^\s*nameserver\s+[a-fA-F0-9:\.]+", re.MULTILINE)
+
+
+def _is_valid_resolv_conf(content: str) -> bool:
+    """A simple check to the contents of a resolv.conf."""
+    return NAMESERVER_PA.search(content) is not None
+
 
 def _load_extra_patterns_from_file(_f: str) -> list[str]:
     _pattern_f = Path(_f)
@@ -134,26 +151,54 @@ class RootfsImagePreparer:
             entry_path = self._rootfs_dir / entry.lstrip("/")
             entry_path.mkdir(exist_ok=True, parents=True)
 
+    def _fixup_resolv_conf(self) -> None:
+        """Ensure /etc/resolv.conf is valid, otherwise fix it up."""
+        resolv_conf = self._rootfs_dir / RESOLV_CONF_RELPATH
+        if resolv_conf.is_symlink():
+            resolv_conf.unlink(missing_ok=True)
+        if resolv_conf.is_dir():  # how could it be a dir?
+            shutil.rmtree(resolv_conf, ignore_errors=True)
+
+        if resolv_conf.is_file():
+            try:
+                if not _is_valid_resolv_conf(resolv_conf.read_text()):
+                    raise ValueError("invalid resolv.conf")
+                return
+            except Exception:
+                resolv_conf.unlink(missing_ok=True)
+        else:  # thing that is not symlink, dir or regular file
+            resolv_conf.unlink(missing_ok=True)
+
+        if not resolv_conf.exists():
+            logger.info(
+                f"{resolv_conf} is missing or invalid, "
+                f"fixing it up as a symlink to {RESOLV_CONF_SYMLINK_TARGET}"
+            )
+            resolv_conf.parent.mkdir(parents=True, exist_ok=True)
+            resolv_conf.symlink_to(RESOLV_CONF_SYMLINK_TARGET)
+
     def prepare(self) -> None:
         """Prepare the system rootfs image."""
         logger.info(f"Preparing system rootfs image: {self._rootfs_dir}")
         self._process_cleanup()
         self._prepare_image()
+        self._fixup_resolv_conf()
         logger.info("System rootfs image prepared successfully.")
 
 
 def prepare_sysimg_cmd_args(
     sub_arg_parser: _SubParsersAction[ArgumentParser], *parent_parser: ArgumentParser
 ) -> None:
+    _cmd_help_text = (
+        "Prepare a system image to make it ready for adding into OTA image. "
+        "This command will do some basic cleanup to the system rootfs image, "
+        "optionally do further cleanup with `--cleanup-pattern-file` specified."
+    )
+
     prepare_sysimg_cmd_args = sub_arg_parser.add_parser(
         name="prepare-sysimg",
-        help=(
-            _help_txt
-            := "Prepare a system image to make it ready for adding into OTA image. "
-            "This command will do some basic cleanup to the system rootfs image, "
-            "optionally do further cleanup with `--cleanup-pattern-file` specified."
-        ),
-        description=_help_txt,
+        help=_cmd_help_text,
+        description=_cmd_help_text,
         parents=parent_parser,
     )
     prepare_sysimg_cmd_args.add_argument(

--- a/tests/unit/cmds/test_prepare_sysimg.py
+++ b/tests/unit/cmds/test_prepare_sysimg.py
@@ -1,0 +1,215 @@
+# Copyright 2025 TIER IV, INC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for cmds/prepare_sysimg.py module."""
+
+from __future__ import annotations
+
+import os
+from argparse import Namespace
+from pathlib import Path
+
+import pytest
+
+from ota_image_builder.cmds.prepare_sysimg import (
+    RESOLV_CONF_RELPATH,
+    RESOLV_CONF_SYMLINK_TARGET,
+    RootfsImagePreparer,
+    _is_valid_resolv_conf,
+    prepare_sysimg_cmd,
+)
+
+
+def _write_resolv_conf(rootfs: Path, content: str) -> Path:
+    """Create <rootfs>/etc/resolv.conf as a regular file with `content`."""
+    resolv_conf = rootfs / RESOLV_CONF_RELPATH
+    resolv_conf.parent.mkdir(parents=True, exist_ok=True)
+    resolv_conf.write_text(content)
+    return resolv_conf
+
+
+class TestIsValidResolvConf:
+    """Tests for the _is_valid_resolv_conf helper."""
+
+    @pytest.mark.parametrize(
+        "content",
+        [
+            "nameserver 8.8.8.8\n",
+            "nameserver 1.1.1.1",
+            "  nameserver 192.168.0.1\n",  # leading whitespace tolerated
+            "nameserver 2001:4860:4860::8888\n",  # IPv6
+            "nameserver fe80::1%eth0\n",  # IPv6 with zone index
+            "# generated file\nsearch example.com\nnameserver 8.8.4.4\n",
+            "options edns0\nnameserver 8.8.8.8 # trailing comment\n",
+        ],
+    )
+    def test_valid_content(self, content: str):
+        assert _is_valid_resolv_conf(content) is True
+
+    @pytest.mark.parametrize(
+        "content",
+        [
+            "",  # empty
+            "\n\n  \n",  # only blank lines
+            "# nameserver 8.8.8.8\n",  # commented out
+            "search example.com\noptions edns0\n",  # no nameserver
+            "nameserver\n",  # nameserver directive without an address
+            "nameservers 8.8.8.8\n",  # not the nameserver directive
+            "nameserver not-an-ip\n",  # addr doesn't look like an IP
+        ],
+    )
+    def test_invalid_content(self, content: str):
+        assert _is_valid_resolv_conf(content) is False
+
+
+class TestFixupResolvConf:
+    """Tests for RootfsImagePreparer._fixup_resolv_conf."""
+
+    def _assert_fixed_up(self, rootfs: Path) -> None:
+        resolv_conf = rootfs / RESOLV_CONF_RELPATH
+        assert resolv_conf.is_symlink()
+        assert os.readlink(resolv_conf) == RESOLV_CONF_SYMLINK_TARGET
+
+    def test_missing_is_fixed(self, tmp_path: Path):
+        (tmp_path / "etc").mkdir()
+        RootfsImagePreparer(tmp_path)._fixup_resolv_conf()
+        self._assert_fixed_up(tmp_path)
+
+    def test_missing_etc_dir_is_created(self, tmp_path: Path):
+        # /etc itself does not exist yet
+        RootfsImagePreparer(tmp_path)._fixup_resolv_conf()
+        self._assert_fixed_up(tmp_path)
+
+    def test_empty_file_is_fixed(self, tmp_path: Path):
+        _write_resolv_conf(tmp_path, "")
+        RootfsImagePreparer(tmp_path)._fixup_resolv_conf()
+        self._assert_fixed_up(tmp_path)
+
+    def test_no_nameserver_file_is_fixed(self, tmp_path: Path):
+        _write_resolv_conf(tmp_path, "search example.com\noptions edns0\n")
+        RootfsImagePreparer(tmp_path)._fixup_resolv_conf()
+        self._assert_fixed_up(tmp_path)
+
+    def test_broken_symlink_is_fixed(self, tmp_path: Path):
+        etc = tmp_path / "etc"
+        etc.mkdir()
+        (etc / "resolv.conf").symlink_to("does-not-exist")
+        RootfsImagePreparer(tmp_path)._fixup_resolv_conf()
+        self._assert_fixed_up(tmp_path)
+
+    def test_directory_is_replaced(self, tmp_path: Path):
+        etc = tmp_path / "etc"
+        etc.mkdir()
+        bogus_dir = etc / "resolv.conf"
+        bogus_dir.mkdir()
+        (bogus_dir / "leftover").write_text("junk")
+        RootfsImagePreparer(tmp_path)._fixup_resolv_conf()
+        self._assert_fixed_up(tmp_path)
+
+    def test_special_file_is_fixed(self, tmp_path: Path):
+        """A non-regular file (e.g. a FIFO) at the path is removed and fixed."""
+        resolv_conf = tmp_path / RESOLV_CONF_RELPATH
+        resolv_conf.parent.mkdir(parents=True)
+        os.mkfifo(resolv_conf)
+        RootfsImagePreparer(tmp_path)._fixup_resolv_conf()
+        self._assert_fixed_up(tmp_path)
+
+    def test_undecodable_file_is_fixed(self, tmp_path: Path):
+        resolv_conf = tmp_path / RESOLV_CONF_RELPATH
+        resolv_conf.parent.mkdir(parents=True)
+        resolv_conf.write_bytes(b"\xff\xfe\x00\x80 not utf-8")
+        RootfsImagePreparer(tmp_path)._fixup_resolv_conf()
+        self._assert_fixed_up(tmp_path)
+
+    def test_valid_regular_file_is_untouched(self, tmp_path: Path):
+        content = "# static config\nnameserver 8.8.8.8\nnameserver 8.8.4.4\n"
+        resolv_conf = _write_resolv_conf(tmp_path, content)
+        RootfsImagePreparer(tmp_path)._fixup_resolv_conf()
+
+        assert not resolv_conf.is_symlink()
+        assert resolv_conf.read_text() == content
+
+    def test_symlink_to_valid_file_is_normalized(self, tmp_path: Path):
+        """Any symlink, even one resolving to valid content, is normalized."""
+        etc = tmp_path / "etc"
+        etc.mkdir()
+        (etc / "resolv.conf.real").write_text("nameserver 1.1.1.1\n")
+        (etc / "resolv.conf").symlink_to("resolv.conf.real")
+
+        RootfsImagePreparer(tmp_path)._fixup_resolv_conf()
+
+        self._assert_fixed_up(tmp_path)
+        # the symlink target file itself is left in place
+        assert (etc / "resolv.conf.real").read_text() == "nameserver 1.1.1.1\n"
+
+    def test_idempotent(self, tmp_path: Path):
+        (tmp_path / "etc").mkdir()
+        preparer = RootfsImagePreparer(tmp_path)
+        preparer._fixup_resolv_conf()
+        preparer._fixup_resolv_conf()  # running again must not raise
+        self._assert_fixed_up(tmp_path)
+
+
+class TestPrepare:
+    """End-to-end tests for RootfsImagePreparer.prepare()."""
+
+    def test_prepare_fixes_resolv_conf(self, tmp_path: Path):
+        # a typical dirty rootfs: runtime dirs present, resolv.conf empty
+        for d in ("dev", "proc", "sys", "run", "tmp", "etc"):
+            (tmp_path / d).mkdir()
+        _write_resolv_conf(tmp_path, "")
+
+        RootfsImagePreparer(tmp_path).prepare()
+
+        resolv_conf = tmp_path / RESOLV_CONF_RELPATH
+        assert resolv_conf.is_symlink()
+        assert os.readlink(resolv_conf) == RESOLV_CONF_SYMLINK_TARGET
+        # runtime dirs are recreated (and emptied) by prepare()
+        for d in ("dev", "proc", "sys", "run", "tmp"):
+            assert (tmp_path / d).is_dir()
+
+    def test_prepare_keeps_valid_resolv_conf(self, tmp_path: Path):
+        for d in ("dev", "proc", "sys", "run", "tmp", "etc"):
+            (tmp_path / d).mkdir()
+        content = "nameserver 10.0.0.1\n"
+        _write_resolv_conf(tmp_path, content)
+
+        RootfsImagePreparer(tmp_path).prepare()
+
+        resolv_conf = tmp_path / RESOLV_CONF_RELPATH
+        assert not resolv_conf.is_symlink()
+        assert resolv_conf.read_text() == content
+
+
+class TestPrepareSysimgCmd:
+    """Tests for the prepare_sysimg_cmd entrypoint."""
+
+    def test_cmd_fixes_resolv_conf(self, tmp_path: Path):
+        rootfs = tmp_path / "rootfs"
+        (rootfs / "etc").mkdir(parents=True)
+        # missing /etc/resolv.conf
+
+        args = Namespace(rootfs_dir=str(rootfs), cleanup_pattern_file=None)
+        prepare_sysimg_cmd(args)
+
+        resolv_conf = rootfs / RESOLV_CONF_RELPATH
+        assert resolv_conf.is_symlink()
+        assert os.readlink(resolv_conf) == RESOLV_CONF_SYMLINK_TARGET
+
+    def test_cmd_rejects_non_directory(self, tmp_path: Path):
+        not_a_dir = tmp_path / "rootfs"
+        not_a_dir.write_text("i am a file")
+
+        args = Namespace(rootfs_dir=str(not_a_dir), cleanup_pattern_file=None)
+        with pytest.raises(SystemExit):
+            prepare_sysimg_cmd(args)


### PR DESCRIPTION
## Introduction

In some cases, the built rootfs image will have an empty `/etc/resolv.conf`, this PR handles these cases, fix up the `/etc/resolv.conf` and make it a symlink points to ` ../run/systemd/resolve/stub-resolv.conf`, following the contract of `systemd-resolvd`.

ota-image-builder v0.12.0 will be released after this PR merged. 

## Motivation

The build scripts are executed by docker on the evaluator, and docker will bind mount /etc/resolv.conf into the build container(so that the build container can have network access during build).
When docker export the build container, bind mount will not be exported, resulting in an always empty place holder being exported.