### PR TITLE
fix(resource_process): make finalize filters order-deterministic

### DIFF
--- a/src/ota_image_builder/v1/_resource_process/_bundle_filter.py
+++ b/src/ota_image_builder/v1/_resource_process/_bundle_filter.py
@@ -270,6 +270,12 @@ class BundleFilterProcesser:
                         "AND", "filter_applied", "IS NULL",
                         end_with=None,
                     ),
+                    # NOTE: an unordered SELECT has no guaranteed row order, it is
+                    #   whatever the query plan yields. Pin it to resource_id so that
+                    #   the bundle packing is reproducible. resource_id follows the
+                    #   rootfs walk order, and keeping that clustering is what keeps
+                    #   the OTA over-fetch low.
+                    order_by=("resource_id",),
                 ),
                 _row_factory=sqlite3.Row,
             ) # type: ignore[assignment]

--- a/src/ota_image_builder/v1/_resource_process/_compression_filter.py
+++ b/src/ota_image_builder/v1/_resource_process/_compression_filter.py
@@ -192,6 +192,9 @@ class CompressionFilterProcesser:
                 select_from=rs_orm.orm_table_name,
                 select_cols=("resource_id", "digest", "size"),
                 where_stmt=f"WHERE size > {self._lower_bound} AND filter_applied IS NULL",
+                # NOTE: pin the row order to resource_id, see the note in
+                #   _bundle_filter.py for the rationale.
+                order_by=("resource_id",),
             )
 
             submit_with_se = func_call_with_se(pool.submit, self._se)
@@ -211,6 +214,13 @@ class CompressionFilterProcesser:
         return origin_size, compressed
 
     def _update_db(self, compressed: CompressionResult) -> None:
+        # NOTE: <compressed> is filled in by the worker threads, so its iteration
+        #   order is the thread completion order. Apply the results in origin
+        #   resource_id order instead, otherwise the resource_ids assigned to the
+        #   newly inserted compressed resources, and thus the resource table blob
+        #   digest, depend on the thread scheduling.
+        _sorted_compressed = sorted(compressed.items())
+
         with self._db_helper.get_orm() as rs_orm:
             # NOTE: DO NOT overwrite the already there resources if any!
             rs_orm.orm_insert_mappings(
@@ -219,14 +229,14 @@ class CompressionFilterProcesser:
                         digest=compressed_digest,
                         size=compressed_size,
                     )
-                    for compressed_digest, compressed_size in compressed.values()
+                    for _, (compressed_digest, compressed_size) in _sorted_compressed
                 ),
                 or_option="ignore",
             )
 
             # batch queries to select compressed entries from db
             compressed_entries: dict[Sha256DigestBytes, ResourceID] = {}
-            for _batch in batched(compressed.values(), SELECT_BATCH_SIZE, strict=False):
+            for _batch in batched(_sorted_compressed, SELECT_BATCH_SIZE, strict=False):
                 _params_holder = ",".join(itertools.repeat("?", len(_batch)))
                 # fmt: off
                 _query_res = rs_orm.orm_execute(
@@ -235,7 +245,7 @@ class CompressionFilterProcesser:
                         "FROM", rs_orm.orm_table_name,
                         "WHERE", "digest", "IN", f"({_params_holder})"
                     ),
-                    params=tuple(_digest[0] for _digest in _batch),
+                    params=tuple(_entry[1][0] for _entry in _batch),
                     row_factory=typing.cast(
                         typing.Callable[..., tuple[Sha256DigestBytes, ResourceID]], sqlite3.Row
                     ),
@@ -244,6 +254,8 @@ class CompressionFilterProcesser:
                 compressed_entries.update(_query_res)
 
             # update the original entries
+            # NOTE: <set_cols_value> and <where_cols_value> are zipped pairwise by
+            #   the ORM, so both MUST iterate <_sorted_compressed> in the same order.
             rs_orm.orm_update_entries_many(
                 set_cols=("filter_applied",),
                 set_cols_value=(
@@ -253,12 +265,12 @@ class CompressionFilterProcesser:
                             compression_alg=ZSTD_COMPRESSION_ALG,
                         )
                     )
-                    for compressed_digest, _ in compressed.values()
+                    for _, (compressed_digest, _) in _sorted_compressed
                 ),
                 where_cols=("resource_id",),
                 where_cols_value=(
                     ResourceTableManifestTypedDict(resource_id=_resource_id)
-                    for _resource_id in compressed
+                    for _resource_id, _ in _sorted_compressed
                 ),
             )
 

--- a/src/ota_image_builder/v1/_resource_process/_slice_filter.py
+++ b/src/ota_image_builder/v1/_resource_process/_slice_filter.py
@@ -189,8 +189,13 @@ class SliceFilterProcesser:
     # ------------------------ #
 
     def _update_db(self, sliced: SliceResult) -> None:
+        # NOTE: <sliced> is appended by the worker threads, so its order is the
+        #   thread completion order. Apply the results in resource_id order instead,
+        #   otherwise the resource_ids assigned to the newly inserted slices, and
+        #   thus the resource table blob digest, depend on the thread scheduling.
+        _sorted_sliced = sorted(sliced, key=lambda _entry: _entry[0])
         with self._db_helper.get_orm() as rs_orm:
-            for batch in batched(sliced, self._update_batch, strict=False):
+            for batch in batched(_sorted_sliced, self._update_batch, strict=False):
                 _update_one_batch(rs_orm, batch)
 
     def _process_slicing(self) -> tuple[int, Size, SliceResult]:
@@ -216,6 +221,9 @@ class SliceFilterProcesser:
                         "AND", "filter_applied IS NULL",
                         end_with=None,
                     ),
+                    # NOTE: pin the row order to resource_id, see the note in
+                    #   _bundle_filter.py for the rationale.
+                    order_by=("resource_id",),
                 ),
                 _row_factory=sqlite3.Row,
             ):

--- a/tests/unit/v1/test_filter_determinism.py
+++ b/tests/unit/v1/test_filter_determinism.py
@@ -1,0 +1,334 @@
+# Copyright 2025 TIER IV, INC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Determinism tests for the finalize phase resource filters.
+
+Filter results must be a pure function of the resource table contents. Two things
+must not leak into them:
+
+1. The SQLite query plan. A SELECT without ORDER BY has no guaranteed row order,
+   it only happens to walk the table in `resource_id` order as long as the planner
+   picks a full table scan (`resource_id` is an INTEGER PRIMARY KEY, hence a rowid
+   alias). Any index the planner prefers changes the visiting order.
+2. The worker thread completion order, which decides in which order the filter
+   results are applied back to the database, and therefore which `resource_id` is
+   assigned to each newly inserted resource.
+
+Both perturb the `resource_id` assignment, and the resource table blob digest is
+recorded in the image index, so either one changes the digest of the shipped image.
+
+NOTE: ordering is always on `resource_id`, never on path or digest. `resource_id`
+is assigned in rootfs walk order, and preserving that clustering is what keeps OTA
+over-fetch low.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from contextlib import closing
+from hashlib import sha256
+from pathlib import Path
+
+from ota_image_builder._common import WriteThreadSafeDict
+from ota_image_builder.v1._resource_process._bundle_filter import BundleFilterProcesser
+from ota_image_builder.v1._resource_process._compression_filter import (
+    CompressionFilterProcesser,
+)
+from ota_image_builder.v1._resource_process._db_utils import (
+    init_resource_table_db,
+    vacuum_db,
+)
+from ota_image_builder.v1._resource_process._slice_filter import (
+    SliceFilterProcesser,
+    SliceResult,
+)
+
+RST_TABLE_NAME = "rs_manifest"
+
+SIZE_BASE = 4096
+SIZE_STEP = 16
+"""Entry sizes are anti-correlated with resource_id: entry N is smaller than entry
+N-1. A query plan that walks a `size` index therefore visits the entries in exactly
+the reverse of `resource_id` order, which makes a dependency on the SELECT row order
+observable.
+"""
+
+
+def _blob_content(resource_id: int, size: int, *, compressible: bool) -> bytes:
+    """Build deterministic, per-resource unique content of exactly <size> bytes."""
+    prefix = f"resource-{resource_id}:".encode()
+    if compressible:
+        return (prefix + b"A" * size)[:size]
+
+    # Not compressible, and every slice of it is unique across resources.
+    _buf, _block = bytearray(), sha256(prefix).digest()
+    while len(_buf) < size:
+        _buf += _block
+        _block = sha256(_block).digest()
+    return bytes(_buf[:size])
+
+
+def _make_entries(count: int, *, compressible: bool) -> list[tuple[int, bytes]]:
+    """Build <count> (resource_id, contents) pairs, resource_id starting from 1."""
+    return [
+        (
+            _resource_id,
+            _blob_content(
+                _resource_id,
+                SIZE_BASE - _resource_id * SIZE_STEP,
+                compressible=compressible,
+            ),
+        )
+        for _resource_id in range(1, count + 1)
+    ]
+
+
+def _seed_db(
+    rst_dbf: Path,
+    entries: list[tuple[int, bytes]],
+    *,
+    perturbed_where: str | None = None,
+) -> None:
+    """Bootstrap a resource table DB and insert <entries> with explicit resource_ids.
+
+    Args:
+        perturbed_where: when set, an index over `size` is created to make the
+            planner abandon the rowid ordered table scan, and the helper asserts
+            that the perturbation actually changed the row order of
+            `SELECT resource_id FROM <table> <perturbed_where>`. Without that
+            self-check the determinism assertions would silently go vacuous if a
+            future SQLite release stopped picking the index.
+    """
+    init_resource_table_db(rst_dbf)
+    with closing(sqlite3.connect(rst_dbf)) as conn:
+        for _resource_id, _contents in entries:
+            conn.execute(
+                f"INSERT INTO {RST_TABLE_NAME} (resource_id, digest, size) VALUES (?,?,?)",
+                (_resource_id, sha256(_contents).digest(), len(_contents)),
+            )
+
+        if perturbed_where is not None:
+            conn.execute(f"CREATE INDEX idx_size ON {RST_TABLE_NAME}(size)")
+        conn.commit()
+
+        if perturbed_where is not None:
+            _visit_order = [
+                _row[0]
+                for _row in conn.execute(
+                    f"SELECT resource_id FROM {RST_TABLE_NAME} {perturbed_where}"
+                )
+            ]
+            assert _visit_order != sorted(_visit_order), (
+                "the query plan perturbation is not effective, "
+                "the determinism assertion would be vacuous"
+            )
+
+
+def _write_blobs(resource_dir: Path, entries: list[tuple[int, bytes]]) -> None:
+    resource_dir.mkdir(parents=True, exist_ok=True)
+    for _, _contents in entries:
+        (resource_dir / sha256(_contents).hexdigest()).write_bytes(_contents)
+
+
+def _dump_table(rst_dbf: Path) -> list[tuple]:
+    with closing(sqlite3.connect(rst_dbf)) as conn:
+        return list(
+            conn.execute(
+                f"SELECT resource_id, digest, size, filter_applied FROM {RST_TABLE_NAME}"
+                " ORDER BY resource_id"
+            )
+        )
+
+
+def _db_digest(rst_dbf: Path) -> str:
+    vacuum_db(rst_dbf)
+    return sha256(rst_dbf.read_bytes()).hexdigest()
+
+
+class TestSelectOrderDeterminism:
+    """The filters must visit resources in resource_id order, not in query plan order."""
+
+    def test_bundle_packs_in_resource_id_order(self, tmp_path: Path):
+        entries = _make_entries(64, compressible=True)
+        lower_bound, upper_bound = 100, SIZE_BASE
+
+        rst_dbf = tmp_path / "resource_table.db"
+        resource_dir = tmp_path / "resources"
+        _seed_db(
+            rst_dbf,
+            entries,
+            perturbed_where=(
+                f"WHERE size > {lower_bound} AND size <= {upper_bound}"
+                " AND filter_applied IS NULL"
+            ),
+        )
+        _write_blobs(resource_dir, entries)
+
+        processer = BundleFilterProcesser(
+            resource_dir=resource_dir,
+            rst_dbf=rst_dbf,
+            bundle_lower_bound=lower_bound,
+            bundle_upper_bound=upper_bound,
+            # each entry is around 4KiB, so each bundle takes exactly 2 entries
+            bundle_blob_size=5000,
+            bundle_compressed_max_sum=64 * 1024 * 1024,
+            protected_resources=set(),
+        )
+        bundle_result = processer._process_bundle()
+
+        packed_resource_ids = [
+            _resource_id
+            for _bundle_res, _ in bundle_result
+            for _resource_id, _ in _bundle_res.bundled_entries
+        ]
+        assert packed_resource_ids == [_resource_id for _resource_id, _ in entries]
+
+    def test_compression_visits_in_resource_id_order(self, tmp_path: Path):
+        """NOTE: driven with a single worker thread and a single concurrent job, so
+        that the completion order equals the SELECT row order and this test is about
+        the SELECT alone.
+        """
+        entries = _make_entries(32, compressible=True)
+        lower_bound = 100
+
+        rst_dbf = tmp_path / "resource_table.db"
+        resource_dir = tmp_path / "resources"
+        _seed_db(
+            rst_dbf,
+            entries,
+            perturbed_where=f"WHERE size > {lower_bound} AND filter_applied IS NULL",
+        )
+        _write_blobs(resource_dir, entries)
+
+        processer = CompressionFilterProcesser(
+            resource_dir=resource_dir,
+            rst_dbf=rst_dbf,
+            size_lower_bound=lower_bound,
+            compression_ratio_threshold=1.1,
+            worker_threads=1,
+            concurrent_jobs=1,
+            protected_resources=set(),
+        )
+        _, compressed = processer._process_compression()
+
+        assert list(compressed) == [_resource_id for _resource_id, _ in entries]
+
+    def test_slice_visits_in_resource_id_order(self, tmp_path: Path):
+        """NOTE: driven with a single worker thread and a single concurrent task, so
+        that the completion order equals the SELECT row order and this test is about
+        the SELECT alone.
+        """
+        entries = _make_entries(32, compressible=False)
+        slice_size = 512
+
+        rst_dbf = tmp_path / "resource_table.db"
+        resource_dir = tmp_path / "resources"
+        _seed_db(
+            rst_dbf,
+            entries,
+            perturbed_where=(
+                f"WHERE size > {slice_size * 2} AND filter_applied IS NULL"
+            ),
+        )
+        _write_blobs(resource_dir, entries)
+
+        processer = SliceFilterProcesser(
+            resource_dir=resource_dir,
+            rst_dbf=rst_dbf,
+            slice_size=slice_size,
+            worker_threads=1,
+            concurrent_tasks=1,
+            protected_resources=set(),
+        )
+        _, _, slice_result = processer._process_slicing()
+
+        assert [_resource_id for _resource_id, _ in slice_result] == [
+            _resource_id for _resource_id, _ in entries
+        ]
+
+
+class TestUpdateOrderDeterminism:
+    """Applying filter results must not depend on the thread completion order."""
+
+    def test_compression_update_is_completion_order_independent(self, tmp_path: Path):
+        entries = _make_entries(16, compressible=True)
+        compression_results = [
+            (
+                _resource_id,
+                (
+                    sha256(f"compressed-{_resource_id}".encode()).digest(),
+                    128 + _resource_id,
+                ),
+            )
+            for _resource_id, _ in entries
+        ]
+
+        db_files: list[Path] = []
+        for _name, _completion_order in (
+            ("in_order", compression_results),
+            ("reversed", list(reversed(compression_results))),
+        ):
+            rst_dbf = tmp_path / f"resource_table_{_name}.db"
+            _seed_db(rst_dbf, entries)
+
+            compressed = WriteThreadSafeDict()
+            for _resource_id, _result in _completion_order:
+                compressed[_resource_id] = _result
+
+            CompressionFilterProcesser(
+                resource_dir=tmp_path,
+                rst_dbf=rst_dbf,
+                protected_resources=set(),
+            )._update_db(compressed)
+            db_files.append(rst_dbf)
+
+        assert _dump_table(db_files[0]) == _dump_table(db_files[1])
+        assert _db_digest(db_files[0]) == _db_digest(db_files[1])
+
+    def test_slice_update_is_append_order_independent(self, tmp_path: Path):
+        entries = _make_entries(16, compressible=False)
+        slice_results = [
+            (
+                _resource_id,
+                {
+                    sha256(f"slice-{_resource_id}-{_idx}".encode()).digest(): 256 + _idx
+                    for _idx in range(2)
+                },
+            )
+            for _resource_id, _ in entries
+        ]
+
+        db_files: list[Path] = []
+        for _name, _completion_order in (
+            ("in_order", slice_results),
+            ("reversed", list(reversed(slice_results))),
+        ):
+            rst_dbf = tmp_path / f"resource_table_{_name}.db"
+            _seed_db(rst_dbf, entries)
+
+            sliced = SliceResult()
+            for _result in _completion_order:
+                sliced.append(_result)
+
+            SliceFilterProcesser(
+                resource_dir=tmp_path,
+                rst_dbf=rst_dbf,
+                # smaller than the number of results, so that the batching itself
+                # also depends on the append order
+                db_update_batch_size=4,
+                protected_resources=set(),
+            )._update_db(sliced)
+            db_files.append(rst_dbf)
+
+        assert _dump_table(db_files[0]) == _dump_table(db_files[1])
+        assert _db_digest(db_files[0]) == _db_digest(db_files[1])


### PR DESCRIPTION
## Description

Two OTA builds from an identical source ref produced different `index.json` — the `resource_table` descriptor differed in digest and size. The `resource_table` blob digest is recorded in the image index, so anything that perturbs the table perturbs the shipped image digest.

`resource_id` is an `INTEGER PRIMARY KEY` (rowid alias), handed out in insertion order, so any reordering moves the ids. This makes the three finalize-phase filters (bundle / compression / slice) a pure function of the resource table they are given, independent of SQLite query planning and worker thread scheduling.

## Check list

- [x] test files that cover the bug case(s) are implemented.
- [x] local tests are passing.

## Bug fix

### Current behavior

Two mechanisms perturb `resource_id` assignment. **They are not equally implicated — please read the attribution before drawing conclusions:**

1. **Unordered `SELECT`s — latent, not currently firing.** All three filters scan with a `WHERE` but no `ORDER BY`; SQLite gives no order guarantee and only walks in `resource_id` order because the planner picks a full table scan. In production no competing index exists (no `CREATE INDEX` in this repo or in `ota_image_libs/v1/resource_table/`; the implicit `UNIQUE(digest)` autoindex cannot serve `WHERE size > ? AND filter_applied IS NULL`). So this is hardening an unguaranteed contract, not a fix for something observed.
2. **Thread-completion-order application — this is the one that was firing.** `_update_db()` in the compression and slice filters iterated containers filled by the worker pool, so `orm_insert_mappings()` inserted in scheduling-dependent order and SQLite assigned scheduling-dependent `resource_id`s. Those ids are embedded in the origin rows' `filter_applied` column, so the perturbation reaches the table *contents* — and hence the `resource_table` digest in `index.json`.

### Behavior after fix

The finalize filters are now deterministic for a given resource table.

- `_bundle_filter.py:278`, `_compression_filter.py:197`, `_slice_filter.py:226` — `order_by=("resource_id",)` added. Passed as a **tuple** because `table_select_stmt` is `@lru_cache`d and every argument must be hashable.
- `_compression_filter.py` `_update_db()` — drives all three steps from one `sorted(compressed.items())`. This matters twice: `set_cols_value` and `where_cols_value` are zipped pairwise by the ORM, so they must iterate the same sequence.
- `_slice_filter.py` `_update_db()` — sorts by origin `resource_id` before `batched(...)`.

Ordering is by `resource_id`, **never** path or digest: `resource_id` follows the rootfs walk order, so it preserves genesis clustering and a delta update touches few bundles. Path order measured 2.42× worse for OTA over-fetch; digest order 7.71× worse.

New `tests/unit/v1/test_filter_determinism.py`, 5 tests, all red on the unfixed code. Suite `305 → 310 passed`. Note the query-plan tests induce reordering with a test-only index over `size` (shuffling inserts proves nothing against a rowid alias) — that `CREATE INDEX` is the only one in the tree and lives in the test file alone.

**Scope — this does not make OTA images byte-reproducible on its own.** The create phase (`_rootfs_process.py`) is untouched and still scheduling-dependent, and the blob-count delta is *not* explained by this PR: both `orm_insert_mappings()` calls use `or_option="ignore"`, so their inserted row set is order-invariant by construction. **Do not expect two builds to converge after merging this** — a residual `index.json` divergence is the expected outcome, not evidence the analysis is wrong.

What this PR does establish is the precondition: without a deterministic finalize you cannot tell a stable input from a stable output, so a create-phase fix could not be verified at all.

## Related links & ticket

**Follow-up: create-phase determinism.** Measured on this commit, against a 304,993-path / 5.51 GB real tree, three runs on one host: 73.0–73.7 % of `rs_manifest.resource_id`, 73.4–74.2 % of `ft_resource.resource_id` and 84.3–84.6 % of `ft_inode.inode_id` differ, with **zero** non-id column differences and an identical blob set — a pure surrogate-id permutation. Three full `init → add-image → finalize` runs produced three different `index.json`.

Cause: `os.walk` at `_rootfs_process.py:332` never sorts `dirnames`/`filenames` and feeds a 6-worker pool; ids are assigned in worker/queue-arrival order, which is redrawn every run. Walk order is not stable across filesystems either.

Proposed fix: sort the walk, and buffer the writer thread's rows to flush canonically — `rs_manifest`/`ft_resource` in **dispatch (walk) order**, not digest order (digest order measured 7.71× over-fetch and +47 % compressed bundle set). A literal implementation still leaves 0.08–0.15 % drift from a dedup race in `ResourceRegister`; re-keying to the first referencing dispatch sequence removes it, after which a prototype produced byte-identical DBs over 4 runs and collapsed the end-to-end difference to a single field (`created-at`, an `int(time.time())` in `ota-image-libs`). Cost: no wall-clock regression, ≈ +480 MiB peak RSS at a 266k-path image.

Caveats: canonicalising ingestion does move packing order (`sorted_walk` measured 2.36× the as-built over-fetch), though a 10-draw permutation lottery places it mid-range — this is **n = 1 pair** and should be re-measured. Hardlink `inode_id = -st_ino` still leaks host inode numbers. The blob-count drift was **not** reproduced on these corpora and is flagged as unreproduced rather than asserted.
